### PR TITLE
transcribe: switch to Deepgram WebSocket API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-deepgram-sdk>=4.0.0
+deepgram-sdk>=4.8.0
 sounddevice==0.5.1
 numpy>=1.26.0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- Replace deprecated Deepgram live client with WebSocket implementation
- Update error messages and comments to reflect WebSocket streaming
- Bump deepgram-sdk requirement to 4.8.0

## Testing
- `python -m py_compile main.py enhance.py`


------
https://chatgpt.com/codex/tasks/task_e_689ea775758c8325a8a7a6a6a3a857ec