### PR TITLE
transcribe: stabilize websocket closes

### DIFF
--- a/tests/test_deepgram_service.py
+++ b/tests/test_deepgram_service.py
@@ -68,3 +68,17 @@ def test_handle_transcript_dict():
     service._handle_transcript(None, result)
     cb.assert_called_once_with("hi", True)
 
+
+def test_finalize_does_not_reconnect():
+    client = MagicMock()
+    ws = MagicMock()
+    service = DeepgramService(client, on_transcript=dummy_callback)
+    service.ws = ws
+    service.start = MagicMock()
+
+    assert service.finalize() is True
+    service._handle_close(None)
+    service.start.assert_not_called()
+    assert service.ws is None
+    assert service._closing is False
+


### PR DESCRIPTION
## Summary
- specify explicit audio parameters for Deepgram live transcription
- avoid reconnecting after an intentional finalize
- cover finalize close behavior with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a011a3433083259ba8aad4b7a9656a