### PR TITLE
Guard optional OpenAI client and update Deepgram stream closing

### DIFF
--- a/deepgram_service.py
+++ b/deepgram_service.py
@@ -51,7 +51,7 @@ class DeepgramService:
 
                 options = LiveOptions(
                     model="nova-3",
-                    language="en",
+                    language="en-US",
                     punctuate=True,
                     smart_format=True,
                     encoding="linear16",
@@ -130,13 +130,12 @@ class DeepgramService:
             return False
 
     def finalize(self) -> bool:
-        """Finalize the current stream."""
+        """Finish the current stream and close the WebSocket."""
 
         if not self.ws:
             return False
         self._closing = True
         try:
-            self.ws.finalize()
             self.ws.finish()
             return True
         except Exception:  # pragma: no cover - network errors

--- a/enhance.py
+++ b/enhance.py
@@ -13,8 +13,11 @@ from dotenv import load_dotenv
 # Load environment variables
 load_dotenv()
 
-# Initialize OpenAI client
-client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+# Initialize OpenAI client if API key is available
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise ImportError("OPENAI_API_KEY not set")
+client = openai.OpenAI(api_key=api_key)
 
 # Enhancement style prompts
 ENHANCEMENT_PROMPTS = {

--- a/tests/test_deepgram_service.py
+++ b/tests/test_deepgram_service.py
@@ -44,7 +44,6 @@ def test_send_and_finalize():
     ws.send.assert_called_once_with(chunk)
 
     assert service.finalize() is True
-    ws.finalize.assert_called_once()
     ws.finish.assert_called_once()
     # Simulate the close event Deepgram emits after finalize so the service
     # can clean up its internal WebSocket reference.
@@ -80,6 +79,7 @@ def test_finalize_does_not_reconnect():
     service.start = MagicMock()
 
     assert service.finalize() is True
+    ws.finish.assert_called_once()
     service._handle_close(None)
     service.start.assert_not_called()
     assert service.ws is None


### PR DESCRIPTION
## Summary
- avoid importing enhancement module when `OPENAI_API_KEY` is missing
- use US English locale and `finish()` when closing Deepgram websockets
- adjust Deepgram service tests for new finish behavior

## Testing
- `pytest`
- `python main.py -v` *(fails: DEEPGRAM_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d78c236483259c94c7640b6473da